### PR TITLE
フィルターがうまく表示されない不具合を修正

### DIFF
--- a/DX22Base/DX22Base.vcxproj
+++ b/DX22Base/DX22Base.vcxproj
@@ -192,7 +192,6 @@
     <ClCompile Include="Texture.cpp" />
     <ClCompile Include="SceneGame.cpp" />
     <ClCompile Include="Title.cpp" />
-    <ClCompile Include="_geometory.cpp" />
     <ClCompile Include="_model.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/DX22Base/DX22Base.vcxproj.filters
+++ b/DX22Base/DX22Base.vcxproj.filters
@@ -51,6 +51,7 @@
     </Filter>
     <Filter Include="ソース ファイル\Geometry">
       <UniqueIdentifier>{4110178c-d2c6-4d5d-854d-552848beea87}</UniqueIdentifier>
+    </Filter>
     <Filter Include="ソース ファイル\Scene">
       <UniqueIdentifier>{3892fbb0-488d-4de1-b651-4b00cf8ea3e5}</UniqueIdentifier>
     </Filter>
@@ -118,6 +119,7 @@
     </ClCompile>
     <ClCompile Include="Geometry.cpp">
       <Filter>ソース ファイル\Geometry</Filter>
+    </ClCompile>
     <ClCompile Include="Scene.cpp">
       <Filter>ソース ファイル\Scene</Filter>
     </ClCompile>
@@ -194,6 +196,7 @@
     </ClInclude>
     <ClInclude Include="Geometry.h">
       <Filter>ヘッダー ファイル\Geometry</Filter>
+    </ClInclude>
     <ClInclude Include="Scene.h">
       <Filter>ヘッダー ファイル\Scene</Filter>
     </ClInclude>


### PR DESCRIPTION
DX22Base.vcxproj.filtersの内容が一部ミスっていた(閉じる部分が抜けていた)ので修正
