### PR TITLE
フェード制作中に見つけたミスを修正

### DIFF
--- a/DX22Base/Camera.cpp
+++ b/DX22Base/Camera.cpp
@@ -17,6 +17,8 @@
 	・2023/11/10 パラメタ修正 takagi
 	・2023/11/11 define用ヘッダ追加 suzumura
 	・2023/11/17 2D表示/3D表示の切換をコンストラクタでなくGetProjectionMatrix()関数で行うように変更 takagi
+	・2023/11/18 2D表示のミスを訂正 takagi
+
 ========================================== */
 
 // =============== インクルード ===================
@@ -161,7 +163,7 @@ DirectX::XMFLOAT4X4 CCamera::GetProjectionMatrix(const E_DRAW_TYPE& eDraw) const
 		// =============== 2D表示 ===================
 	case E_DRAW_TYPE_2D:	//2Dのプロジェクション座標作成
 		DirectX::XMStoreFloat4x4(&mat, DirectX::XMMatrixTranspose(
-			DirectX::XMMatrixOrthographicOffCenterLH(0.0f, SCREEN_WIDTH, SCREEN_HEIGHT, 0.0f, m_fNear, m_fFar)));	//左下を原点(0,0)とした座標系
+			DirectX::XMMatrixOrthographicOffCenterLH(0.0f, SCREEN_WIDTH, 0.0f, SCREEN_HEIGHT, m_fNear, m_fFar)));	//左下を原点(0,0)とした座標系
 		break;	//分岐処理終了
 
 		// =============== 3D表示 ===================


### PR DESCRIPTION
カメラの2D表示でプロジェクション行列を取得するときの引数の順番が誤っていたため修正しました