### PR TITLE
Hitstopを衝突時発生に変更

### DIFF
--- a/DX22Base/CollisionOfStage.cpp
+++ b/DX22Base/CollisionOfStage.cpp
@@ -12,6 +12,7 @@
 	変更履歴
 	・2023/11/16 制作 takagi
 	・2023/11/29 ヒットストップ仕様変更対応 takagi
+	・2023/11/30 ヒットストップをハンマー激突時に変更 takagi
 
 ========================================== */
 
@@ -19,6 +20,8 @@
 #include "Stage.h"	//自身のヘッダ
 #include "GameParameter.h"
 #include "HitStop.h"	//ヒットストップ
+#include "Slime_4.h"	//赤スライム種分けよう
+#include <typeinfo.h>	//typeid使用
 
 
 /* ========================================
@@ -133,6 +136,15 @@ void CStage::HammerSlimeCollision()
 		// スライムとハンマーが衝突した場合
 		if (m_pCollision->CheckCollisionSphere(playerHammer->GetSphere(), pSlimeNow->GetSphere(), playerHammer->GetPos(), pSlimeNow->GetPos()))
 		{
+			//赤スライムと激突したときだけヒットストップの時間を長くする
+			if (typeid(CSlime_4) == typeid(*pSlimeNow))
+			{
+				CHitStop::UpFlag(CHitStop::E_BIT_FLAG_STOP_NORMAL);	//ヒットストップ
+			}
+			else
+			{
+				CHitStop::UpFlag(CHitStop::E_BIT_FLAG_STOP_SOFT);	//ヒットストップ
+			}
 			float fAngleSlime
 				= m_pPlayer->GetTransform().Angle(pSlimeNow->GetTransform());	// スライムが飛ぶ角度を取得
 
@@ -166,6 +178,7 @@ void CStage::HammerBossCollision()
 		// スライムとハンマーが衝突した場合
 		if (m_pCollision->CheckCollisionSphere(playerHammer->GetSphere(), pBossNow->GetSphere(), playerHammer->GetPos(), pBossNow->GetPos()))
 		{
+			CHitStop::UpFlag(CHitStop::E_BIT_FLAG_STOP_NORMAL);	//ヒットストップ
 			float fAngleSlime
 				= m_pPlayer->GetTransform().Angle(pBossNow->GetTransform());	// スライムが飛ぶ角度を取得
 

--- a/DX22Base/Main.h
+++ b/DX22Base/Main.h
@@ -15,7 +15,7 @@
 
 // =============== デバッグモード ===================
 #if _DEBUG
-#define USE_SCENE_MANAGER (false)
+#define USE_SCENE_MANAGER (true)
 #endif
 
 #ifndef __MAIN_H__

--- a/DX22Base/SlimeManager.cpp
+++ b/DX22Base/SlimeManager.cpp
@@ -32,6 +32,7 @@
 	・2023/11/27 赤赤の爆発生成時にヒットストップと画面揺れするように修正	Sawada
 	・2023/11/29 画面揺れを横強→縦強に変更 takagi
 	・2023/11/29 プレイヤーのポインタを取得 yamashita
+	・2023/11/30 ヒットストップ除去 takagi
 
 =========================================== */
 
@@ -384,8 +385,6 @@ void CSlimeManager::HitBranch(int HitSlimeNum, int StandSlimeNum, CExplosionMana
 
 		if (hitSlimeLevel == MAX_LEVEL)	//スライムのサイズが最大の時
 		{
-			CHitStop::UpFlag(CHitStop::E_BIT_FLAG_STOP_SOFT);	//フラグオン
-
 			//スライム爆発処理
 			pExpMng->Create(pos, MAX_SIZE_EXPLODE * EXPLODE_BASE_RATIO, LEVEL_4_EXPLODE_TIME, LEVEL_4_EXPLODE_DAMAGE, E_SLIME_LEVEL::LEVEL_4x4);	//衝突されたスライムの位置でレベル４爆発
 			m_pScoreOHMng->DisplayOverheadScore(pos, LEVEL_4_SCORE * 2, SLIME_SCORE_HEIGHT);


### PR DESCRIPTION
フィードバックを受け、ヒットストップの発生場所を変更しました。ヒットストップの時間長すぎて最悪の体験ができます

やっぱ良くないので修正します　マージしないで