### PR TITLE
デビルスライムの着地時の高速移動バグを修正

### DIFF
--- a/DX22Base/SlimeManager.cpp
+++ b/DX22Base/SlimeManager.cpp
@@ -389,7 +389,7 @@ void CSlimeManager::Create(E_SLIME_LEVEL level)
 			m_pSlime[i] = new CSlime_4(CreatePos, m_pVS, m_pRedModel);	// 動的生成
 			break;
 		case LEVEL_FLAME:
-			m_pSlime[i] = new CSlime_Flame(CreatePos, 0.5f, m_flameSlimeEffect, m_pVS,m_pFlameModel);	// 動的生成
+			m_pSlime[i] = new CSlime_Flame(CreatePos, m_flameSlimeEffect, m_pVS,m_pFlameModel);	// 動的生成
 			break;
 		case LEVEL_HEAL:
 			m_pSlime[i] = new CSlime_Heal(CreatePos, m_pVS, m_pHealModel);	//動的生成

--- a/DX22Base/Slime_Boss_2.cpp
+++ b/DX22Base/Slime_Boss_2.cpp
@@ -10,6 +10,7 @@
 	変更履歴
 	・2023/12/12 クラス作成 Sawada
 	・2023/12/14 攻撃動作を追加 Sawada
+	・2024/01/23 着地時の高速移動バグを修正 Sawada
 
 ========================================== */
 
@@ -184,6 +185,7 @@ void CSlime_Boss_2::MoveSwitch()
 	{
 	// 移動処理
 	case MOVE_STATE::NORMAL:
+		SetNormalSpeed();	// 移動スピードをリセット(直前の吹き飛び速度を無くす為)
 		MoveNormal();
 
 		break;

--- a/DX22Base/Slime_Flame.cpp
+++ b/DX22Base/Slime_Flame.cpp
@@ -59,7 +59,7 @@ CSlime_Flame::CSlime_Flame()
 	-------------------------------------
 	戻値：無し
 =========================================== */
-CSlime_Flame::CSlime_Flame(TPos3d<float> pos, float fSize, Effekseer::EffectRef flameSlimeEffect, VertexShader* pVS, Model* pModel)
+CSlime_Flame::CSlime_Flame(TPos3d<float> pos, Effekseer::EffectRef flameSlimeEffect, VertexShader* pVS, Model* pModel)
 	: CSlime_Flame()
 {
 	m_Transform.fPos = pos;			// 初期座標を指定

--- a/DX22Base/Slime_Flame.h
+++ b/DX22Base/Slime_Flame.h
@@ -27,7 +27,7 @@ class CSlime_Flame :
 public:
 	// ===プロトタイプ宣言===
 	CSlime_Flame();
-	CSlime_Flame(TPos3d<float> pos, float fSize, Effekseer::EffectRef flameSlimeEffect, VertexShader* pVS, Model* pModel);
+	CSlime_Flame(TPos3d<float> pos, Effekseer::EffectRef flameSlimeEffect, VertexShader* pVS, Model* pModel);
 	~CSlime_Flame();
 	void NormalMove() override;
 	void SetNormalSpeed() override;


### PR DESCRIPTION
吹き飛び中にジャンプ処理に遷移することで速度がリセットされていないことが原因のため、ノーマル移動の際に必ず速度をセットするように修正