### PR TITLE
タイマーとボスゲージのスケールモーション追加

### DIFF
--- a/DX22Base/BossGauge.h
+++ b/DX22Base/BossGauge.h
@@ -12,6 +12,7 @@
 	・2023/11/19 ボスゲージ増加する変数、関数を作成 Tei
 	・2023/11/22 ボスゲージフェード用変数追加 Tei
 	・2023/11/26 スライム管理メンバ変数追加	Sawada
+	・2024/02/16 ボスゲージスケールモーション追加 Tei
 
 ========================================== */
 #ifndef __BOSS_GAUGE_H__
@@ -60,6 +61,7 @@ public:
 	void SetShowWarning(CShowWarning* pShowWarn);
 
 	void AddBossGauge(int BossNum, float fStartTime, float fMaxTime);
+	void BossGaugeScaleMotion(float fSize, int nFlame);	//ボスゲージスケール関数
 
 private:
 	// ===メンバ変数宣言===
@@ -70,6 +72,9 @@ private:
 	std::vector<BossGauge> m_BossGauges;	// ボスゲージ管理配列(ステージ毎に生成する数配列に格納する)
 
 	CShowWarning* m_pShowWarn;				// ボス警告
+
+	float m_fBossgaugeScale;				// ボスゲージスケール倍率
+	int m_nBossgaugeScaleCnt;				// ボスゲージスケールのフレームカウント
 };
 
 

--- a/DX22Base/Timer.cpp
+++ b/DX22Base/Timer.cpp
@@ -16,6 +16,7 @@
 	E2023/12/07 ƒQ[ƒ€ƒpƒ‰ƒ[ƒ^‚©‚çˆê•”’è”ˆÚ“®EˆÃ–Ù‚ÌŒ^ƒLƒƒƒXƒgœ‹ takagi
 	E2023/12/08 GetErapsedTime()ŠÖ”’Ç‰Á takagi
 	E2024/01/01 Œp³—p‘‚«Š·‚¦ Takagi
+	E2024/02/16 ƒ^ƒCƒ}[ƒXƒP[ƒ‹ƒ‚[ƒVƒ‡ƒ“’Ç‰Á Tei
 
 ========================================== */
 
@@ -34,7 +35,12 @@ const float TIME_BACK_GROUND_SIZE_X = 200.0f;								//ƒ^ƒCƒ}[‚ÌƒoƒbƒNƒOƒ‰ƒ“ƒh‚
 const float TIME_BACK_GROUND_SIZE_Y = -75.0f;								//ƒ^ƒCƒ}[‚ÌƒoƒbƒNƒOƒ‰ƒ“ƒh‚ÌY‚Ì’·‚³İ’è
 const float TIME_COLON_SIZE_X = 35.0f;										//ƒ^ƒCƒ}[‚ÌƒRƒƒ“‚ÌX‚Ì’·‚³İ’è
 const float TIME_COLON_SIZE_Y = -35.0f;										//ƒ^ƒCƒ}[‚ÌƒRƒƒ“‚ÌY‚Ì’·‚³İ’è
-
+const int TIME_LEFT_TIRTHY_SEC = 30 * 60;									//ŠÔc‚è30•b
+const int TIME_LEFT_TEN_SEC = 10 * 60;										//ŠÔc‚è10•b
+const float TIME_LEFT_SCALE_TIRTHY = 0.005;		// c‚è30•bŠg‘åk¬‚Ì”ä—¦
+const float TIME_LEFT_SCALE_TEN = 0.02f;		// c‚è10•bŠg‘åk¬‚Ì”ä—¦(­‚µ‘å‚«‚­)
+const int TIME_SCALE_SPEED_TIRTHY = 100;			// Šg‘åk¬ˆê‰ñ‚ÌƒtƒŒ[ƒ€”(100flameˆê‰ñ’x‚¢)
+const int  TIME_SCALE_SPEED_TEN = 30;		// Šg‘åk¬ˆê‰ñ‚ÌƒtƒŒ[ƒ€”(30flameˆê‰ñ‘¬‚¢)
 //const float SLM_PARAM_CHANGE_TIME[STATE_MAX] = { 60.0f, 120.0f, 180.0f };	// Œo‰ßŠÔ‚Ì•b”
 //const int	SLM_CREATE_NUM[STATE_MAX] = { 20, 25, MAX_SLIME_NUM };			// Å‘å¶¬”
 //const float SLM_CREATE_INTERVAL_TIME[STATE_MAX] = { 1.0f, 1.5f, 1.5f };		// ¶¬ŠÔŠu
@@ -66,6 +72,8 @@ CTimer::CTimer()
 	, m_afSlimeCreateInterval{ {0.0f} }		// ’iŠK•ÊƒXƒ‰ƒCƒ€¶¬ŠÔŠu
 	, m_afSlimeMoveSpeed{ {0.0f} }			// ’iŠK•ÊƒXƒ‰ƒCƒ€ƒXƒs[ƒh
 	, m_afSlimeParamChangeTime{ {0.0f} }	// ’iŠK•ÊƒXƒ‰ƒCƒ€Œ`‘Ô•Ï‰»ŠÔ
+	, m_fTimerScale(1.0f)		// ŠÔ•’i‚ÌƒXƒP[ƒ‹”{—¦
+	, m_nTimerScaleCnt(0)
 {
 	//”š‚ÌƒeƒNƒXƒ`ƒƒ“Ç‚Ş‚İ
 
@@ -132,6 +140,19 @@ void CTimer::Update()
 	}
 	// ƒ^ƒCƒ}[Œ¸Z
 	m_nTimeCnt--;
+
+	// ŠÔc‚è30•b‚Ì‚Æ‚«A”š‚ªŠg‘åk¬‚·‚é
+	if (m_nTimeCnt <= TIME_LEFT_TIRTHY_SEC && m_nTimeCnt >= TIME_LEFT_TEN_SEC)
+	{
+		TimerScaleMotion(TIME_LEFT_SCALE_TIRTHY, TIME_SCALE_SPEED_TIRTHY);
+	}
+	// ŠÔc‚è10•b‚Ì‚Æ‚«A‚à‚Á‚Æ‘¬‚ß‚ÉŠg‘åk¬‚·‚é
+	else if (m_nTimeCnt <= TIME_LEFT_TEN_SEC)
+	{
+		TimerScaleMotion(TIME_LEFT_SCALE_TEN, TIME_SCALE_SPEED_TEN);
+	}
+	else
+	{ }
 	//ŠÔ‚ª0‚É‚È‚Á‚½‚çI—¹ˆ—‚É
 	if (m_nTimeCnt <= 0)
 	{
@@ -335,7 +356,7 @@ void CTimer::DrawNumber(TPos2d<float> pos, int number)
 	Sprite::SetWorld(time[0]);
 	Sprite::SetView(time[1]);
 	Sprite::SetProjection(time[2]);
-	Sprite::SetSize(DirectX::XMFLOAT2(50.0f, -50.0f));
+	Sprite::SetSize(DirectX::XMFLOAT2(50.0f * m_fTimerScale, -50.0f * m_fTimerScale));
 
 	//spriteƒV[ƒg‚Ìã•”•ª•\¦i0~4j
 	if ((number % 10) < 5)
@@ -350,6 +371,29 @@ void CTimer::DrawNumber(TPos2d<float> pos, int number)
 	Sprite::SetUVScale(DirectX::XMFLOAT2(0.2f, 0.5f));
 	Sprite::SetTexture(m_pTextureNum);
 	Sprite::Draw();
+}
+
+/* ========================================
+	ƒ^ƒCƒ}[Šg‘åk¬ŠÖ”
+	----------------------------------------
+	“à—eFƒ^ƒCƒ}[Šg‘åk¬‚·‚é
+	----------------------------------------
+	ˆø”1FŠg‘åk¬‚ÌƒTƒCƒY
+	ˆø”2Fˆê‰ñ‚ÌŠg‘åk¬‚ÌƒtƒŒ[ƒ€”
+	----------------------------------------
+	–ß’lF‚È‚µ
+=========================================== */
+void CTimer::TimerScaleMotion(float fSize, int nFlame)
+{
+	m_nTimerScaleCnt++;									// ƒ^ƒCƒ}[ƒtƒŒ[ƒ€ƒJƒEƒ“ƒg‰ÁZ
+	if (m_nTimerScaleCnt % nFlame <= (nFlame / 2) - 1)	//İ’è‚µ‚½ƒtƒŒ[ƒ€”‚Ì‘O”¼‰ÁZ(Šg‘å)AŒã”¼Œ¸Z(k¬)
+	{
+		m_fTimerScale += fSize;
+	}
+	else
+	{
+		m_fTimerScale -= fSize;
+	}
 }
 
 /* ========================================

--- a/DX22Base/Timer.h
+++ b/DX22Base/Timer.h
@@ -13,6 +13,7 @@
 	・2023/12/07 ゲームパラメータに依存していたので修正・不足インクルード解消・ゲームパラメータから一部定数移動 takagi
 	・2023/12/08 GetErapsedTime()関数追加 takagi
 	・2024/01/01 継承用書き換え Takagi
+	・2024/02/16 タイマースケールモーション追加 Tei
 
 ========================================== */
 #ifndef __TIMER_H__
@@ -53,6 +54,7 @@ public:
 	void TimeStop();
 	void TimeRestart();
 	void DrawNumber(TPos2d<float> pos, int number);	//数字描画関数
+	void TimerScaleMotion(float fSize, int nFlame);	//時間の数字スケール関数
 
 	int* GetTimePtr();
 	int GetMaxSlimeNum();							// スライム最大生成数を取得
@@ -79,6 +81,8 @@ private:
 	int m_nMaxSlimeNum;			// スライムの最大生成数
 	int m_nSlimeCreateInterval;	// スライム生成間隔
 	float m_fSlimeMoveSpeed;	// スライムスピード
+	float m_fTimerScale;		// タイマー数字スケール倍率
+	int m_nTimerScaleCnt;		// タイマー数字スケールのフレームカウント
 
 	Texture* m_pTextureNum;	//タイマー表示用テクスチャポインタ
 	Texture* m_pTextureBG;


### PR DESCRIPTION
Timer.cppとBossGauge.cppにスケールモーション関数追加
ボスゲージが拡大縮小するようになりました。ボスゲージが一定値（7割）を貯まったら、速めに拡大縮小する。
残り時間30秒から、タイマーの数字が拡大縮小します。残り時間10秒になったら、もっと速めに拡大縮小する。